### PR TITLE
Add symbol to allow easier pipeline use.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>test-notifications</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>hpi</packaging>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
@@ -17,6 +17,7 @@ import jenkins.tasks.SimpleBuildStep;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpException;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -188,6 +189,7 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
     }
 
     @Extension
+    @Symbol("sendTestResults")
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         @Override


### PR DESCRIPTION
See: https://www.jenkins.io/doc/developer/plugin-development/pipeline-integration/#defining-symbols

This allows the use of the plugin within a pipeline with:
`sendTestResults credentialsId: 'CREDENTIALS-ID, notificationUrl: 'NOTIFICATION-URL'`

Without this change, the following has to be used:
`step([$class: 'SendTestResultsNotificationPostBuildTask', credentialsId: 'CREDENTIALS-ID', notificationUrl: 'NOTIFICATION-URL''])`