### PR TITLE
[Feature] More Flexible Format for Transmission of Test Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ where the attributes are:
 * `name`: This is the name of the test case as it will be shown for example on the ‘Configure Grading’ page.
   It should therefore have a for this exercise uniquely identifiable name and **has to be non-null**.
 * `successful`: Indicates if the test case execution for this submission should be marked as successful or failed.
-* `message`: The message shown as additional information to the student. (optional)
+* `message`: The message shown as additional information to the student.
+  **Required for non-sucessful feedback**, optional otherwise.
 
 Additionally, the plugin will parse and send reports created by static code analysis. The tools Spotbugs, Checkstyle and PMD are currently supported.
 The plugin only considers XML reports in the directory _staticCodeAnalysisReports_.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ The plugin will collect and merge **all** JUnit formatted test results in the _r
 So, you have to copy or generate all JUnit XML files under this directory, the plugin will take care of merging
 multiple files and posting the results to the specified endpoint.
 
+The JUnit format is limited to allow messages only for failing test cases.
+To circumvent this limitation and allow custom tools to easily send additional feedbacks to Artemis another approach is possible.
+To achieve this, a directory _customFeedbacks_ has to be created.
+Then this plugin will read all JSON files written to this directory and integrate them into the report sent to Artemis.
+The JSON files must have the correct file ending `.json` and have to be in the format
+```json
+{
+  "name": "string",
+  "successful": boolean,
+  "message": "string"
+}
+```
+where the attributes are:
+* `name`: This is the name of the test case as it will be shown for example on the ‘Configure Grading’ page.
+  It should therefore have a for this exercise uniquely identifiable name and **has to be non-null**.
+* `successful`: Indicates if the test case execution for this submission should be marked as successful or failed.
+* `message`: The message shown as additional information to the student. (optional)
+
 Additionally, the plugin will parse and send reports created by static code analysis. The tools Spotbugs, Checkstyle and PMD are currently supported.
 The plugin only considers XML reports in the directory _staticCodeAnalysisReports_.
 
@@ -44,7 +62,7 @@ Email: krusche[at]in[dot]tum[dot]de
     }
   ],
   "errors": 0,
-  "failures": 4,
+  "failures": 5,
   "fullName": "SOME-FOLDER » SOME-JOB #42",
   "results": [
     {
@@ -63,6 +81,7 @@ Email: krusche[at]in[dot]tum[dot]de
               "type": "java.lang.AssertionError"
             }
           ],
+          "successInfos": null,
           "name": "testAdapterValue",
           "time": 0.011
         }
@@ -86,6 +105,7 @@ Email: krusche[at]in[dot]tum[dot]de
               "type": "java.lang.AssertionError"
             }
           ],
+          "successInfos": null,
           "name": "testAttributes[ThermoAdapter]",
           "time": 0.008
         }
@@ -109,6 +129,7 @@ Email: krusche[at]in[dot]tum[dot]de
               "type": "java.lang.AssertionError"
             }
           ],
+          "successInfos": null,
           "name": "testClass[ThermoAdapter]",
           "time": 0.014
         }
@@ -132,12 +153,42 @@ Email: krusche[at]in[dot]tum[dot]de
               "type": "java.lang.AssertionError"
             }
           ],
+          "successInfos": null,
           "name": "testMethods[ThermoAdapter]",
           "time": 0.078
         }
       ],
       "tests": 1,
       "time": 0.078
+    },
+    {
+      "errors": 0,
+      "failures": 1,
+      "name": "customFeedbackReports",
+      "skipped": 0,
+      "testCases": [
+        {
+          "errors": null,
+          "failures": null,
+          "successInfos": [
+            {
+              "message": "A custom message for a successful test case as defined in the JSON."
+            }
+          ],
+          "name": "customFeedbackName001"
+        },
+        {
+          "errors": null,
+          "failures": [
+            {
+              "message": "A custom message for a non-succesful test case as defined in the JSON."
+            }
+          ],
+          "successInfos": null,
+          "name": "customFeedbackName002"
+        }
+      ],
+      "tests": 2
     }
   ],
   "staticCodeAnalysisReports":[

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/CustomFeedbackParser.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/CustomFeedbackParser.java
@@ -1,0 +1,122 @@
+package de.tum.in.www1.jenkins.notifications;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.InvalidPropertiesFormatException;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+
+import com.google.gson.Gson;
+
+import de.tum.in.www1.jenkins.notifications.model.*;
+
+import hudson.FilePath;
+import hudson.model.TaskListener;
+
+public class CustomFeedbackParser {
+
+    private CustomFeedbackParser() {
+    }
+
+    /**
+     * Reads all {@link CustomFeedback} JSONs from the directory and converts them into a {@link Testsuite}
+     *
+     * @param taskListener needed to provide useful error messages in the Jenkins log.
+     * @param resultsDir the directory to read the feedback files from.
+     * @return a {@link Testsuite} if at least one valid {@link CustomFeedback} has been found, empty otherwise.
+     * @throws IOException if the resultsDir is not readable.
+     * @throws InterruptedException if the resultsDir is not readable.
+     */
+    public static Optional<Testsuite> extractCustomFeedbacks(@Nonnull TaskListener taskListener, FilePath resultsDir) throws IOException, InterruptedException {
+        final Gson gson = new Gson();
+        final List<CustomFeedback> feedbacks = resultsDir.list()
+                .stream()
+                .filter(path -> path.getName().endsWith(".json"))
+                .map((Function<FilePath, Optional<CustomFeedback>>) feedbackFile -> {
+                    try {
+                        final CustomFeedback feedback = gson.fromJson(feedbackFile.readToString(), CustomFeedback.class);
+                        if (feedback.getMessage() != null && feedback.getMessage().trim().isEmpty()) {
+                            feedback.setMessage(null);
+                        }
+                        validateCustomFeedback(feedbackFile.getName(), feedback);
+                        return Optional.of(feedback);
+                    }
+                    catch (IOException | InterruptedException e) {
+                        taskListener.error(e.getMessage(), e);
+                        return Optional.empty();
+                    }
+                })
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+
+        if (feedbacks.isEmpty()) {
+            return Optional.empty();
+        }
+        else {
+            return Optional.of(customFeedbacksToTestSuite(feedbacks));
+        }
+    }
+
+    /**
+     * Checks that the custom feedback has a valid format
+     * <p>
+     * A custom feedback has to have a non-empty, non only-whitespace name to be able to identify it in Artemis.
+     * If it is not successful, there has to be a message explaining a reason why this is the case.
+     *
+     * @param fileName where the custom feedback was read from.
+     * @param feedback the custom feedback to validate.
+     * @throws InvalidPropertiesFormatException if one of the invariants described above does not hold.
+     */
+    private static void validateCustomFeedback(final String fileName, final CustomFeedback feedback) throws InvalidPropertiesFormatException {
+        if (feedback.getName() == null || feedback.getName().trim().isEmpty()) {
+            throw new InvalidPropertiesFormatException(String.format("Custom feedback from file %s needs to have a name attribute.", fileName));
+        }
+        if (!feedback.isSuccessful() && feedback.getMessage() == null) {
+            throw new InvalidPropertiesFormatException(String.format("Custom non-success feedback from file %s needs to have a message", fileName));
+        }
+    }
+
+    /**
+     * Convert the feedbacks into {@link TestCase}s and wrap them in a {@link Testsuite}
+     *
+     * @param feedbacks the list of parsed custom feedbacks to wrap
+     * @return a Testsuite in the same format as used by JUnit reports
+     */
+    private static Testsuite customFeedbacksToTestSuite(final List<CustomFeedback> feedbacks) {
+        final Testsuite suite = new Testsuite();
+        suite.setName("customFeedbackReports");
+
+        final List<TestCase> testCases = feedbacks.stream().map(feedback -> {
+            final TestCase testCase = new TestCase();
+            testCase.setName(feedback.getName());
+
+            if (feedback.isSuccessful()) {
+                final SuccessInfo successInfo = new SuccessInfo();
+                successInfo.setMessage(feedback.getMessage());
+                final List<SuccessInfo> infos = new ArrayList<>();
+                infos.add(successInfo);
+
+                testCase.setSuccessInfos(infos);
+            }
+            else {
+                final Failure failure = new Failure();
+                failure.setMessage(feedback.getMessage());
+                final List<Failure> failures = new ArrayList<>();
+                failures.add(failure);
+
+                testCase.setFailures(failures);
+            }
+
+            return testCase;
+        }).collect(Collectors.toList());
+
+        suite.setTestCases(testCases);
+
+        return suite;
+    }
+}

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
@@ -1,14 +1,36 @@
 package de.tum.in.www1.jenkins.notifications;
 
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+import jenkins.model.Jenkins;
+import jenkins.tasks.SimpleBuildStep;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpException;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.google.gson.Gson;
+
 import de.tum.in.ase.parser.ReportParser;
 import de.tum.in.ase.parser.domain.Report;
 import de.tum.in.ase.parser.exception.ParserException;
 import de.tum.in.www1.jenkins.notifications.exception.TestParsingException;
 import de.tum.in.www1.jenkins.notifications.model.*;
+
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -23,23 +45,6 @@ import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import jenkins.model.Jenkins;
-import jenkins.tasks.SimpleBuildStep;
-import org.apache.commons.lang.StringUtils;
-import org.apache.http.HttpException;
-import org.jenkinsci.Symbol;
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-import org.kohsuke.stapler.AncestorInPath;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-
-import javax.annotation.Nonnull;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import java.io.IOException;
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class SendTestResultsNotificationPostBuildTask extends Recorder implements SimpleBuildStep {
 
@@ -179,7 +184,8 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
                             throw new IOException("Custom feedbacks need to have a name attribute.");
                         }
                         return feedback;
-                    } catch (IOException | InterruptedException e) {
+                    }
+                    catch (IOException | InterruptedException e) {
                         taskListener.error(e.getMessage(), e);
                         throw new TestParsingException(e);
                     }
@@ -187,7 +193,8 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
 
         if (feedbacks.isEmpty()) {
             return Optional.empty();
-        } else {
+        }
+        else {
             return Optional.of(customFeedbacksToTestSuite(feedbacks));
         }
     }
@@ -213,7 +220,8 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
                 infos.add(successInfo);
 
                 testCase.setSuccessInfos(infos);
-            } else {
+            }
+            else {
                 final Failure failure = new Failure();
                 failure.setMessage(feedback.getMessage());
                 final List<Failure> failures = new ArrayList<>();

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
@@ -49,9 +49,9 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
 
     private static final String TEST_RESULTS_PATH = "results";
 
-    private static final String STATIC_CODE_ANALYSIS_REPORTS_PATH = "staticCodeAnalysisReports";
+    private static final String CUSTOM_FEEDBACKS_PATH = "customFeedbacks";
 
-    private static final String CUSTOM_FEEDBACKS_RESULTS_PATH = "customFeedbacks";
+    private static final String STATIC_CODE_ANALYSIS_REPORTS_PATH = "staticCodeAnalysisReports";
 
     private String credentialsId;
 
@@ -67,10 +67,12 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener taskListener)
             throws InterruptedException, IOException {
         final FilePath testResultsDir = filePath.child(TEST_RESULTS_PATH);
+        final FilePath customFeedbacksDir = filePath.child(CUSTOM_FEEDBACKS_PATH);
         final FilePath staticCodeAnalysisResultsDir = filePath.child(STATIC_CODE_ANALYSIS_REPORTS_PATH);
 
         final List<Testsuite> testReports = extractTestResults(taskListener, testResultsDir);
-        CustomFeedbackParser.extractCustomFeedbacks(taskListener, filePath.child(CUSTOM_FEEDBACKS_RESULTS_PATH)).ifPresent(testReports::add);
+        final Optional<Testsuite> customFeedbacks = CustomFeedbackParser.extractCustomFeedbacks(taskListener, customFeedbacksDir);
+        customFeedbacks.ifPresent(testReports::add);
         final List<Report> staticCodeAnalysisReport = parseStaticCodeAnalysisReports(taskListener, staticCodeAnalysisResultsDir);
 
         final TestResults results = combineTestResults(run, testReports, staticCodeAnalysisReport);

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/CustomFeedback.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/CustomFeedback.java
@@ -1,0 +1,31 @@
+package de.tum.in.www1.jenkins.notifications.model;
+
+public class CustomFeedback {
+    private String name;
+    private boolean successful;
+    private String message;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+
+    public void setSuccessful(boolean successful) {
+        this.successful = successful;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/CustomFeedback.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/CustomFeedback.java
@@ -1,8 +1,11 @@
 package de.tum.in.www1.jenkins.notifications.model;
 
 public class CustomFeedback {
+
     private String name;
+
     private boolean successful;
+
     private String message;
 
     public String getName() {

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/Failure.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/Failure.java
@@ -30,8 +30,16 @@ public class Failure {
         return messageWithStackTrace;
     }
 
+    public void setMessageWithStackTrace(String messageWithStackTrace) {
+        this.messageWithStackTrace = messageWithStackTrace;
+    }
+
     @XmlAttribute
     public String getType() {
         return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 }

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/Failure.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/Failure.java
@@ -1,17 +1,19 @@
 package de.tum.in.www1.jenkins.notifications.model;
 
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
-
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlValue;
 
+import org.kohsuke.stapler.export.ExportedBean;
+
 @ExportedBean(defaultVisibility = 4)
 @XmlRootElement(name = "failure")
 public class Failure {
+
     private String message;
+
     private String messageWithStackTrace;
+
     private String type;
 
     @XmlAttribute

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/SuccessInfo.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/SuccessInfo.java
@@ -8,8 +8,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlValue;
 
 @ExportedBean(defaultVisibility = 4)
-@XmlRootElement(name = "failure")
-public class Failure {
+@XmlRootElement(name = "successInfo")
+public class SuccessInfo {
     private String message;
     private String messageWithStackTrace;
     private String type;

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/SuccessInfo.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/SuccessInfo.java
@@ -1,17 +1,19 @@
 package de.tum.in.www1.jenkins.notifications.model;
 
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
-
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlValue;
 
+import org.kohsuke.stapler.export.ExportedBean;
+
 @ExportedBean(defaultVisibility = 4)
 @XmlRootElement(name = "successInfo")
 public class SuccessInfo {
+
     private String message;
+
     private String messageWithStackTrace;
+
     private String type;
 
     @XmlAttribute

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/TestCase.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/TestCase.java
@@ -1,23 +1,30 @@
 package de.tum.in.www1.jenkins.notifications.model;
 
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
+import java.util.List;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.List;
+
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 @ExportedBean(defaultVisibility = 3)
 @XmlRootElement(name = "testcase")
 public class TestCase {
+
     private String name;
+
     @XmlAttribute
     private String classname;
+
     @XmlAttribute
     private double time;
+
     private List<Failure> failures;
+
     private List<Error> errors;
+
     private List<SuccessInfo> successInfos;
 
     @XmlAttribute

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/TestCase.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/TestCase.java
@@ -11,7 +11,6 @@ import java.util.List;
 @ExportedBean(defaultVisibility = 3)
 @XmlRootElement(name = "testcase")
 public class TestCase {
-    @XmlAttribute
     private String name;
     @XmlAttribute
     private String classname;
@@ -19,10 +18,15 @@ public class TestCase {
     private double time;
     private List<Failure> failures;
     private List<Error> errors;
+    private List<SuccessInfo> successInfos;
 
-    @Exported
+    @XmlAttribute
     public String getName() {
         return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     @Exported
@@ -53,5 +57,15 @@ public class TestCase {
     @XmlElement(name = "error")
     public void setErrors(List<Error> errors) {
         this.errors = errors;
+    }
+
+    @Exported
+    public List<SuccessInfo> getSuccessInfos() {
+        return successInfos;
+    }
+
+    @XmlElement(name = "successInfo")
+    public void setSuccessInfos(List<SuccessInfo> successInfos) {
+        this.successInfos = successInfos;
     }
 }

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/Testsuite.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/Testsuite.java
@@ -1,27 +1,35 @@
 package de.tum.in.www1.jenkins.notifications.model;
 
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
+import java.util.List;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.List;
+
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 @ExportedBean(defaultVisibility = 2)
 @XmlRootElement(name = "testsuite")
 public class Testsuite {
+
     private String name;
+
     @XmlAttribute
     private double time;
+
     @XmlAttribute
     private int errors;
+
     @XmlAttribute
     private int skipped;
+
     @XmlAttribute
     private int failures;
+
     @XmlAttribute
     private int tests;
+
     private List<TestCase> testCases;
 
     @XmlAttribute

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/Testsuite.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/Testsuite.java
@@ -11,7 +11,6 @@ import java.util.List;
 @ExportedBean(defaultVisibility = 2)
 @XmlRootElement(name = "testsuite")
 public class Testsuite {
-    @XmlAttribute
     private String name;
     @XmlAttribute
     private double time;
@@ -25,9 +24,13 @@ public class Testsuite {
     private int tests;
     private List<TestCase> testCases;
 
-    @Exported
+    @XmlAttribute
     public String getName() {
         return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     @Exported


### PR DESCRIPTION
This is part of issue ls1intum/Artemis#2861 and pull request ls1intum/Artemis#2881.

The only format-change Artemis sees is the additional field `successInfos` next to `errors` and `failures`. As this additional field is unknown to Artemis before PR 2881 parsing a new result from Jenkins fails.

However, users are not forced to update the Jenkins plugin after Artemis can handle this additional field. It will simply be set to `null` there if the Jenkins result does not include it and does not produce any errors.