### PR TITLE
Configured ClassFilter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>test-notifications</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <packaging>hpi</packaging>
     <organization>
         <name>LS1 TUM</name>

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,2 @@
+de.tum.in.ase.parser.domain.Report
+de.tum.in.ase.parser.domain.Issue


### PR DESCRIPTION
Resolves #13 

This PR defines class filters. Therefore, the warnings `Refusing to marshal de.tum.in.ase.parser.domain.Report for security reasons` should disappear after merging this PR.