### PR TITLE
Include testwise coverage reports into notification payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,29 @@ Email: krusche[at]in[dot]tum[dot]de
         ]
      }
   ],
+  "testwiseCoverageReport": [
+    {
+      "duration": 0.026,
+      "result": "PASSED",
+      "paths": [
+        {
+          "path": "de/tum/in/ase",
+          "files": [
+            {
+              "fileName": "BubbleSort.java",
+              "coveredLines": "5,14-19,24"
+            },
+            {
+              "fileName": "SortingExampleBehaviorTest.java",
+              "coveredLines": "34-38,40-42,47-49,52"
+            }
+          ]
+        }
+      ],
+      "uniformPath": "de/tum/in/ase/SortingExampleBehaviorTest/testBubbleSort()",
+      "sourcePath": "de/tum/in/ase/SortingExampleBehaviorTest"
+    }
+  ],
   "runDate": "2020-02-19T14:42:42.084Z[Etc/UTC]",
   "skipped": 0,
   "successful": 0

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
@@ -194,7 +194,8 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
 
             String fileContent = optionalReport.get().readToString();
             return new JSONObject(fileContent).getJSONArray("tests");
-        } catch (Throwable t) {
+        }
+        catch (Throwable t) {
             // catch type Throwable to be safe
             return new JSONArray();
         }

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
@@ -14,9 +14,6 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 
@@ -31,6 +28,9 @@ import org.kohsuke.stapler.QueryParameter;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.sun.xml.bind.v2.ContextFactory;
 
 import de.tum.in.ase.parser.domain.Report;

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/TestResults.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/TestResults.java
@@ -6,9 +6,10 @@ import java.util.List;
 
 import javax.annotation.CheckForNull;
 
-import com.google.gson.JsonArray;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
+
+import com.google.gson.JsonArray;
 
 import de.tum.in.ase.parser.domain.Report;
 

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/TestResults.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/TestResults.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import javax.annotation.CheckForNull;
 
-import org.json.JSONArray;
+import com.google.gson.JsonArray;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -34,7 +34,7 @@ public class TestResults implements Action {
 
     private List<Report> staticCodeAnalysisReports;
 
-    private JSONArray testwiseCoverageReport;
+    private JsonArray testwiseCoverageReport;
 
     private String runDate = ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
 
@@ -124,11 +124,11 @@ public class TestResults implements Action {
     }
 
     @Exported
-    public JSONArray getTestwiseCoverageReport() {
+    public JsonArray getTestwiseCoverageReport() {
         return testwiseCoverageReport;
     }
 
-    public void setTestwiseCoverageReport(JSONArray testwiseCoverageReport) {
+    public void setTestwiseCoverageReport(JsonArray testwiseCoverageReport) {
         this.testwiseCoverageReport = testwiseCoverageReport;
     }
 

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/TestResults.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/TestResults.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.annotation.CheckForNull;
 
+import org.json.JSONArray;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -32,6 +33,8 @@ public class TestResults implements Action {
     private List<Testsuite> results;
 
     private List<Report> staticCodeAnalysisReports;
+
+    private JSONArray testwiseCoverageReport;
 
     private String runDate = ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
 
@@ -118,6 +121,15 @@ public class TestResults implements Action {
 
     public void setStaticCodeAnalysisReports(List<Report> staticCodeAnalysisReports) {
         this.staticCodeAnalysisReports = staticCodeAnalysisReports;
+    }
+
+    @Exported
+    public JSONArray getTestwiseCoverageReport() {
+        return testwiseCoverageReport;
+    }
+
+    public void setTestwiseCoverageReport(JSONArray testwiseCoverageReport) {
+        this.testwiseCoverageReport = testwiseCoverageReport;
     }
 
     @Exported


### PR DESCRIPTION
### Checklist
- [x] I built and deployed the plugin locally and tested *all* changes and *all* related features.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
As part of the Bachelor Thesis from @Hialus and @ole-ve about the automatic generation of code hints for programming exercises (HESTIA) in Java, testwise coverage has to be recorded. This is done within the SOLUTION build plan created by Artemis and executed on Bamboo.
In order for Artemis to receive this coverage data, the notification payload has to be extended to include this data.

### Description
The relevant part of the notification looks as following:
```json
"results": [
      {
        "testwiseCoverageReport": [
          {
            "duration": 0.036,
            "paths": [
              {
                "files": [
                  {
                    "coveredLines": "6",
                    "fileName": "BubbleSort.java"
                  },
                  {
                    "coveredLines": "6,12,16-17,20-21,24",
                    "fileName": "Context.java"
                  },
                  {
                    "coveredLines": "9-11,17,21-22,24",
                    "fileName": "Policy.java"
                  }
                ],
                "path": "de/tum/in/ase"
              }
            ],
            "result": "PASSED",
            "sourcePath": "de/tum/in/ase/SortingExampleBehaviorTest",
            "uniformPath": "de/tum/in/ase/SortingExampleBehaviorTest/testUseBubbleSortForSmallList()"
          },
          {
            "duration": 0.027,
            "paths": [
              {
                "files": [
                  {
                    "coveredLines": "6,12,16-17,20-21,24",
                    "fileName": "Context.java"
                  },
                  {
                    "coveredLines": "6",
                    "fileName": "MergeSort.java"
                  },
                  {
                    "coveredLines": "9-11,17-19,24",
                    "fileName": "Policy.java"
                  }
                ],
                "path": "de/tum/in/ase"
              }
            ],
            "result": "PASSED",
            "sourcePath": "de/tum/in/ase/SortingExampleBehaviorTest",
            "uniformPath": "de/tum/in/ase/SortingExampleBehaviorTest/testUseMergeSortForBigList()"
          }
        ]
      }
    ],
```

### Steps for Testing
1. Deploy the plugin on a local Jenkins installation
2. Upload a .json-file to the test repository folder `testwiseCoverageReport`. This simulates the creation of the coverage data, which is not part of this PR. You can use [this file](https://drive.google.com/file/d/1iH26Zb5Ko2EESIxcIhI6jnd9PaECVpt7/view?usp=sharing) as an exemplary coverage result file.
3. Start the build plan. Once it is finished, check in the Artemis-Server console that the notification sent contains the data from the .json-file.
