### PR TITLE
Parse nested test suites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,14 +44,21 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
-    	<dependency>
-			<groupId>io.jenkins.plugins</groupId>
-			<artifactId>jaxb</artifactId>
-			<version>2.3.0.1</version>
-		</dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jaxb</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
@@ -59,7 +66,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.7</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -69,7 +76,17 @@
         <dependency>
             <groupId>de.tum.in.ase</groupId>
             <artifactId>static-code-analysis-parser</artifactId>
-            <version>1.3.4</version>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -92,6 +109,26 @@
     -->
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
@@ -110,7 +110,8 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
             try {
                 final JAXBContext context = createJAXBContext();
                 final Unmarshaller unmarshaller = context.createUnmarshaller();
-                return (Testsuite) unmarshaller.unmarshal(report.read());
+                Testsuite testsuite = (Testsuite) unmarshaller.unmarshal(report.read());
+                return testsuite.flatten();
             }
             catch (JAXBException | IOException | InterruptedException e) {
                 taskListener.error(e.getMessage(), e);

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/Testsuite.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/Testsuite.java
@@ -1,6 +1,8 @@
 package de.tum.in.www1.jenkins.notifications.model;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
@@ -29,6 +31,8 @@ public class Testsuite {
 
     @XmlAttribute
     private int tests;
+
+    private List<Testsuite> testSuites;
 
     private List<TestCase> testCases;
 
@@ -74,5 +78,60 @@ public class Testsuite {
     @XmlElement(name = "testcase")
     public void setTestCases(List<TestCase> testCases) {
         this.testCases = testCases;
+    }
+
+    @Exported
+    public List<Testsuite> getTestSuites() {
+        return testSuites;
+    }
+
+    @XmlElement(name = "testsuite")
+    public void setTestSuites(List<Testsuite> testSuites) {
+        this.testSuites = testSuites;
+    }
+
+    /**
+     * Combines the test suite and all child test suites recursively into a single test suite.
+     *
+     * @return This test suite with all children suites merged into it.
+     */
+    public Testsuite flatten() {
+        if (testSuites != null) {
+            testSuites.stream().map(Testsuite::flatten).forEach(this::addOther);
+
+            // make sure the testSuites are null, as they should not be exported in the JSON back to Artemis
+            testSuites = null;
+        }
+
+        return this;
+    }
+
+    /**
+     * Merges the other test suite into this one.
+     *
+     * @param other Some other test suite.
+     */
+    private void addOther(final Testsuite other) {
+        // the basic attributes of nested test suites are already aggregated here
+
+        if (this.testCases == null) {
+            this.testCases = new ArrayList<>();
+        }
+        if (other.testCases != null) {
+            List<TestCase> otherTestCases = other.testCases.stream().map(testCase -> {
+                testCase.setName(buildTestCaseName(other, testCase));
+                return testCase;
+            }).collect(Collectors.toList());
+            this.testCases.addAll(otherTestCases);
+        }
+    }
+
+    private static String buildTestCaseName(final Testsuite suite, final TestCase testCase) {
+        if (suite.name == null) {
+            return testCase.getName();
+        }
+        else {
+            return suite.name + '.' + testCase.getName();
+        }
     }
 }

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/Testsuite.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/Testsuite.java
@@ -96,6 +96,8 @@ public class Testsuite {
      * @return This test suite with all children suites merged into it.
      */
     public Testsuite flatten() {
+        initTestCaseCounts();
+
         if (testSuites != null) {
             testSuites.stream().map(Testsuite::flatten).forEach(this::addOther);
 
@@ -107,22 +109,60 @@ public class Testsuite {
     }
 
     /**
+     * Initializes the number of test cases, errors, and failures from the list of test cases.
+     * <p>
+     * Not all test runners add the number of errors and failures to the suite information.
+     * Therefore, consistency has to be ensured manually here.
+     */
+    private void initTestCaseCounts() {
+        errors = 0;
+        failures = 0;
+        tests = 0;
+
+        if (testCases != null) {
+            updateTestCaseCounts(testCases);
+        }
+    }
+
+    /**
      * Merges the other test suite into this one.
      *
      * @param other Some other test suite.
      */
     private void addOther(final Testsuite other) {
-        // the basic attributes of nested test suites are already aggregated here
-
-        if (this.testCases == null) {
-            this.testCases = new ArrayList<>();
+        if (testCases == null) {
+            testCases = new ArrayList<>();
         }
+
         if (other.testCases != null) {
             List<TestCase> otherTestCases = other.testCases.stream().map(testCase -> {
                 testCase.setName(buildTestCaseName(other, testCase));
                 return testCase;
             }).collect(Collectors.toList());
-            this.testCases.addAll(otherTestCases);
+
+            skipped += other.skipped;
+            updateTestCaseCounts(otherTestCases);
+            testCases.addAll(otherTestCases);
+        }
+    }
+
+    /**
+     * Updates the test case count, number of errors, and number of failures in this test suite.
+     * <p>
+     * Does <em>not</em> add the test cases themselves to the list of {@link #getTestCases()}.
+     *
+     * @param additionalTestCases The test case that will be separately added to the test cases of this suite.
+     */
+    private void updateTestCaseCounts(final List<TestCase> additionalTestCases) {
+        tests += additionalTestCases.size();
+
+        for (final TestCase testCase : additionalTestCases) {
+            if (testCase.getFailures() != null) {
+                failures += 1;
+            }
+            if (testCase.getErrors() != null) {
+                errors += 1;
+            }
         }
     }
 

--- a/src/test/java/de/tum/in/www1/jenkins/notifications/model/TestsuiteTest.java
+++ b/src/test/java/de/tum/in/www1/jenkins/notifications/model/TestsuiteTest.java
@@ -26,8 +26,11 @@ class TestsuiteTest {
 
         Testsuite flattened = input.flatten();
         assertNull(flattened.getTestSuites());
+
         assertEquals(12, flattened.getTests());
         assertEquals(12, flattened.getTestCases().size());
+        assertEquals(0, flattened.getErrors());
+        assertEquals(0, flattened.getFailures());
     }
 
     @Test
@@ -53,10 +56,11 @@ class TestsuiteTest {
 
         Testsuite flattened = input.flatten();
         assertNull(flattened.getTestSuites());
+
         assertEquals(12, flattened.getTests());
         assertEquals(12, flattened.getTestCases().size());
-        long testsWithFailures = flattened.getTestCases().stream().filter(testCase -> testCase.getFailures() != null).count();
-        assertEquals(2, testsWithFailures);
+        assertEquals(2, flattened.getFailures());
+        assertEquals(1, flattened.getErrors());
     }
 
     private Testsuite loadTestSuite(final Path reportXml) throws JAXBException {

--- a/src/test/java/de/tum/in/www1/jenkins/notifications/model/TestsuiteTest.java
+++ b/src/test/java/de/tum/in/www1/jenkins/notifications/model/TestsuiteTest.java
@@ -1,0 +1,74 @@
+package de.tum.in.www1.jenkins.notifications.model;
+
+import com.sun.xml.bind.v2.ContextFactory;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import java.io.*;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TestsuiteTest {
+
+    @Test
+    void testFlattenNestedSuiteSuccessful() throws Exception {
+        Testsuite input = loadTestSuite(Paths.get("nested_successful.xml"));
+        assertEquals(2, input.getTestSuites().size());
+
+        Testsuite flattened = input.flatten();
+        assertNull(flattened.getTestSuites());
+        assertEquals(12, flattened.getTests());
+        assertEquals(12, flattened.getTestCases().size());
+    }
+
+    @Test
+    void testFlattenBuildTestCaseNames() throws Exception {
+        Testsuite testSuite = loadTestSuite(Paths.get("nested_successful.xml")).flatten();
+
+        List<String> expectedTestCaseNames = new ArrayList<>();
+        expectedTestCaseNames.add("Properties.Checked by SmallCheck.Testing filtering in A");
+        expectedTestCaseNames.add("Testing selectAndReflectA (0,0) []");
+
+        List<String> actualTestCaseNames = testSuite.getTestCases().stream().map(TestCase::getName).collect(Collectors.toList());
+
+        for (String testCaseName : expectedTestCaseNames) {
+            Optional<String> testCase = actualTestCaseNames.stream().filter(testCaseName::equals).findFirst();
+            assertTrue(testCase.isPresent(), String.format("Did not find test case '%s' in %s", testCaseName, actualTestCaseNames));
+        }
+    }
+
+    @Test
+    void testFlattenNestedSuiteWithFailures() throws Exception {
+        Testsuite input = loadTestSuite(Paths.get("nested_with_failures.xml"));
+        assertEquals(2, input.getTestSuites().size());
+
+        Testsuite flattened = input.flatten();
+        assertNull(flattened.getTestSuites());
+        assertEquals(12, flattened.getTests());
+        assertEquals(12, flattened.getTestCases().size());
+        long testsWithFailures = flattened.getTestCases().stream().filter(testCase -> testCase.getFailures() != null).count();
+        assertEquals(2, testsWithFailures);
+    }
+
+    private Testsuite loadTestSuite(final Path reportXml) throws JAXBException {
+        Path resourcePath = new File("testsuite_examples").toPath().resolve(reportXml);
+        URL resource = getClass().getClassLoader().getResource(resourcePath.toString());
+
+        final JAXBContext context = createJAXBContext();
+        final Unmarshaller unmarshaller = context.createUnmarshaller();
+        return (Testsuite) unmarshaller.unmarshal(resource);
+    }
+
+    private JAXBContext createJAXBContext() throws JAXBException {
+        return ContextFactory.createContext(ObjectFactory.class.getPackage().getName(), ObjectFactory.class.getClassLoader(), null);
+    }
+}

--- a/src/test/resources/testsuite_examples/nested_successful.xml
+++ b/src/test/resources/testsuite_examples/nested_successful.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' ?>
+<testsuite name="Tests" tests="12">
+    <testsuite name="Properties" tests="9">
+        <testsuite name="Checked by SmallCheck" tests="6">
+            <testcase name="Testing filtering in A" time="0.004" classname="Tests.Properties.Checked by SmallCheck" />
+            <testcase name="Testing mapping in A" time="0.000" classname="Tests.Properties.Checked by SmallCheck" />
+            <testcase name="Testing filtering in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck" />
+            <testcase name="Testing mapping in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck" />
+            <testcase name="Testing filtering in C" time="0.003" classname="Tests.Properties.Checked by SmallCheck" />
+            <testcase name="Testing mapping in C" time="0.000" classname="Tests.Properties.Checked by SmallCheck" />
+        </testsuite>
+        <testsuite name="Checked by QuickCheck" tests="3">
+            <testcase name="Testing A against sample solution" time="0.001" classname="Tests.Properties.Checked by QuickCheck" />
+            <testcase name="Testing B against sample solution" time="0.001" classname="Tests.Properties.Checked by QuickCheck" />
+            <testcase name="Testing C against sample solution" time="0.001" classname="Tests.Properties.Checked by QuickCheck" />
+        </testsuite>
+    </testsuite>
+    <!-- artificially introduce unnamed test suite -->
+    <testsuite tests="3">
+        <testcase name="Testing selectAndReflectA (0,0) []" time="0.000" classname="Tests.Unit Tests" />
+        <testcase name="Testing selectAndReflectB (0,1) [(0,0)]" time="0.000" classname="Tests.Unit Tests" />
+        <testcase name="Testing selectAndReflectC (0,1) [(-1,-1)]" time="0.000" classname="Tests.Unit Tests" />
+        <testsuite name="Empty Testsuite" tests="0">
+            <!-- intentionally empty -->
+        </testsuite>
+    </testsuite>
+</testsuite>

--- a/src/test/resources/testsuite_examples/nested_with_failures.xml
+++ b/src/test/resources/testsuite_examples/nested_with_failures.xml
@@ -11,7 +11,9 @@
             <testcase name="Testing filtering in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
             <testcase name="Testing mapping in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
             <testcase name="Testing filtering in C" time="0.002" classname="Tests.Properties.Checked by SmallCheck"/>
-            <testcase name="Testing mapping in C" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+            <testcase name="Testing mapping in C" time="0.000" classname="Tests.Properties.Checked by SmallCheck">
+                <error>Some error message</error>
+            </testcase>
         </testsuite>
         <testsuite name="Checked by QuickCheck" tests="3">
             <testcase name="Testing A against sample solution" time="0.000"

--- a/src/test/resources/testsuite_examples/nested_with_failures.xml
+++ b/src/test/resources/testsuite_examples/nested_with_failures.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' ?>
+<testsuite name="Tests" tests="12">
+    <testsuite name="Properties" tests="9">
+        <testsuite name="Checked by SmallCheck" tests="6">
+            <testcase name="Testing filtering in A" time="0.000" classname="Tests.Properties.Checked by SmallCheck">
+                <failure>there exist (0,1) [(1,0)] such that
+                    condition is false
+                </failure>
+            </testcase>
+            <testcase name="Testing mapping in A" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+            <testcase name="Testing filtering in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+            <testcase name="Testing mapping in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+            <testcase name="Testing filtering in C" time="0.002" classname="Tests.Properties.Checked by SmallCheck"/>
+            <testcase name="Testing mapping in C" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+        </testsuite>
+        <testsuite name="Checked by QuickCheck" tests="3">
+            <testcase name="Testing A against sample solution" time="0.000"
+                      classname="Tests.Properties.Checked by QuickCheck">
+                <failure>*** Failed! (after 5 tests and 5 shrinks):
+
+                    &gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; expected
+                    [ ( 1 , 0 ) ]
+                    &gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; but got
+                    [ ( -2 , 0 ) ]
+                    (0,1)
+                    [(1,0)]
+                    Use --quickcheck-replay=220998 to reproduce.
+                </failure>
+            </testcase>
+            <testcase name="Testing B against sample solution" time="0.000"
+                      classname="Tests.Properties.Checked by QuickCheck"/>
+            <testcase name="Testing C against sample solution" time="0.000"
+                      classname="Tests.Properties.Checked by QuickCheck"/>
+        </testsuite>
+    </testsuite>
+    <testsuite name="Unit Tests" tests="3">
+        <testcase name="Testing selectAndReflectA (0,0) []" time="0.000" classname="Tests.Unit Tests"/>
+        <testcase name="Testing selectAndReflectB (0,1) [(0,0)]" time="0.000" classname="Tests.Unit Tests"/>
+        <testcase name="Testing selectAndReflectC (0,1) [(-1,-1)]" time="0.000" classname="Tests.Unit Tests"/>
+    </testsuite>
+</testsuite>


### PR DESCRIPTION
E.g., the Haskell test runner produces a JUnit-XML that has nested `testsuites` instead of a single test suite with only test cases:

```xml
<?xml version='1.0' ?>
<testsuite name="Tests" tests="12">
	<testsuite name="Properties" tests="9">
		<testsuite name="Checked by SmallCheck" tests="6">
			<testcase name="Testing filtering in A" time="0.004" classname="Tests.Properties.Checked by SmallCheck" />
			<testcase name="Testing mapping in A" time="0.000" classname="Tests.Properties.Checked by SmallCheck" />
			<testcase name="Testing filtering in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck" />
			<testcase name="Testing mapping in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck" />
			<testcase name="Testing filtering in C" time="0.003" classname="Tests.Properties.Checked by SmallCheck" />
			<testcase name="Testing mapping in C" time="0.000" classname="Tests.Properties.Checked by SmallCheck" />
		</testsuite>
		<testsuite name="Checked by QuickCheck" tests="3">
			<testcase name="Testing A against sample solution" time="0.001" classname="Tests.Properties.Checked by QuickCheck" />
			<testcase name="Testing B against sample solution" time="0.001" classname="Tests.Properties.Checked by QuickCheck" />
			<testcase name="Testing C against sample solution" time="0.001" classname="Tests.Properties.Checked by QuickCheck" />
		</testsuite>
	</testsuite>
	<testsuite name="Unit Tests" tests="3">
		<testcase name="Testing selectAndReflectA (0,0) []" time="0.000" classname="Tests.Unit Tests" />
		<testcase name="Testing selectAndReflectB (0,1) [(0,0)]" time="0.000" classname="Tests.Unit Tests" />
		<testcase name="Testing selectAndReflectC (0,1) [(-1,-1)]" time="0.000" classname="Tests.Unit Tests" />
	</testsuite>
</testsuite>
```

This PR extends the parser for test suites to allow for those cases. They are handled by merging all test cases of children test suites into the parent test suite, thereby flattening them into a single suite while aggregating the number of test cases, and passed/failed/skipped tests.

By scoping the test case names along the path of the nesting with the usual package name scheme of Java packages, the test case names that were unique before are still unique.
E.g., the test case `Testing filtering in A` from the example above will be turned into `Properties.Checked by SmallCheck.Testing filtering in A`.