### PR TITLE
Print more helpful message when sending feedback to Artemis fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>test-notifications</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
     <packaging>hpi</packaging>
     <organization>
         <name>LS1 TUM</name>

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/HttpHelper.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/HttpHelper.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.jenkins.notifications;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpException;
@@ -23,9 +24,16 @@ public class HttpHelper {
                 .execute()
                 .returnResponse();
 
+        checkError(response);
+    }
+
+    private static void checkError(final HttpResponse response) throws IOException, HttpException {
         if (response.getStatusLine().getStatusCode() != 200) {
-            throw new HttpException(String.format(Messages.SendTestResultsNotificationPostBuildTask_errors_postFailed(),
-                    response.getStatusLine().getStatusCode(), IOUtils.toString(response.getEntity().getContent())));
+            final int statusCode = response.getStatusLine().getStatusCode();
+            final String errorMessage = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+            final String messageTemplate = Messages.SendTestResultsNotificationPostBuildTask_errors_postFailed();
+
+            throw new HttpException(String.format(messageTemplate, statusCode, errorMessage));
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/SendTestResultsNotificationPostBuildTask.java
@@ -92,12 +92,15 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
         final StringCredentials credentials = CredentialsProvider.findCredentialById(credentialsId, StringCredentials.class, run, Collections.emptyList());
         final String secret = credentials != null ? credentials.getSecret().getPlainText() : "Credentials containing the Notification Plugin Secret not found";
 
-        // Post results to notification URL
+        postBuildResults(taskListener, results, secret);
+    }
+
+    private void postBuildResults(@Nonnull TaskListener taskListener, TestResults results, String secret) throws IOException {
         try {
             HttpHelper.postTestResults(results, notificationUrl, secret);
         }
         catch (HttpException e) {
-            taskListener.error(e.getMessage(), e);
+            taskListener.error(e.getMessage());
         }
     }
 
@@ -110,7 +113,7 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
                 return testsuite.flatten();
             }
             catch (JAXBException | IOException | InterruptedException e) {
-                taskListener.error(e.getMessage(), e);
+                taskListener.error(e.getMessage());
                 throw new TestParsingException(e);
             }
         }).collect(Collectors.toList());
@@ -130,7 +133,7 @@ public class SendTestResultsNotificationPostBuildTask extends Recorder implement
             Collections.addAll(logs, logString.split("\n"));
         }
         catch (IOException ex) {
-            taskListener.error(ex.getMessage(), ex);
+            taskListener.error(ex.getMessage());
         }
 
         return logs;


### PR DESCRIPTION
Closes #22.

Most logging frameworks accept the exception as last parameter to a `warn` or `error` log message to print the stack trace as well as the message.

However, in this case `TaskListener::error` is implemented as
```java
    @NonNull
    default PrintWriter error(String format, Object... args) {
        return this.error(String.format(format, args));
    }
```
Therefore, in this case messages that were not intended to be used as format strings got used as such. This led to errors in case the message by chance contained `%F`, which the formatter tried to replace with the exception `e`.
This of course does not work.

The main change of this PR is the removal of the second parameters in the calls to `taskListener.error` in `SendTestResultsNotificationPostBuildTask`.

Some smaller surrounding code quality improvements have been made while checking how the error described in the linked issue could happen.


@dfuchss and me noticed the same error message as well recently when debugging the cause for https://github.com/ls1intum/Artemis/issues/6149, https://github.com/ls1intum/Artemis/pull/6150.

/cc @daniels98it