### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
       - '!.github/workflows/**'
 
 env:
-  java: 1.8
+  java: 11
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   java: 11
+  java-distribution: "temurin"
 
 jobs:
 
@@ -22,14 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: '${{ env.java }}'
-      - uses: actions/checkout@v2
+          distribution: '${{ env.java-distribution }}'
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -65,7 +67,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Download pre-build artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: plugin
           path: staging
@@ -89,12 +91,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: '${{ env.java }}'
-      - uses: actions/checkout@v2
+          distribution: '${{ env.java-distribution }}'
+      - uses: actions/checkout@v3
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.16</version>
+        <version>4.55</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>test-notifications</artifactId>
-    <version>1.7.1</version>
+    <version>1.8.0</version>
     <packaging>hpi</packaging>
     <organization>
         <name>LS1 TUM</name>
@@ -17,9 +17,9 @@
     </organization>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.303.1</jenkins.version>
-        <java.level>8</java.level>
-        <spotless.version>2.12.1</spotless.version>
+        <jenkins.version>2.361.4</jenkins.version>
+        <java.level>11</java.level>
+        <spotless.version>2.33.0</spotless.version>
         <!-- Other properties you may want to use:
           ~ jenkins-test-harness.version: Jenkins Test Harness version you use to test the plugin. For Jenkins version >= 1.580.1 use JTH 2.0 or higher.
           ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
@@ -37,47 +37,48 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <!-- Pick up common dependencies for 2.164.x: https://github.com/jenkinsci/bom#usage -->
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.277.x</artifactId>
-                <version>26</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1841.v7b_22c5218e1a</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.8.2</version>
+                <version>5.9.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <!-- jenkins plugin dependencies -->
+        <!-- the compatible versions are automatically determined by the jenkins bom -->
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>jaxb</artifactId>
-            <version>2.3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.9.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.7</version>
+        </dependency>
+        <!-- other dependencies -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>de.tum.in.ase</groupId>
             <artifactId>static-code-analysis-parser</artifactId>
             <version>1.4.0</version>
         </dependency>
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
@@ -109,6 +110,11 @@
     -->
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.15.0</version>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
### Description

This PR updates various dependencies.

As a major change, the minimum supported Jenkins version has been bumped to version 2.361.x released in the beginning of September last year [1]. This is the first LTS release of Jenkins that _requires_ Java 11 rather than Java 8 [2]. Therefore, it is a good candidate as a baseline that would allow us to upgrade to Java 11 while being forward-compatible.


### Tests

- [x] I tested this plugin on a test server at Uni Passau.

---

[1] https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.361.1
[2] https://www.jenkins.io/blog/2022/06/28/require-java-11/