### PR TITLE
Add Jenkins security scan CI step

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -1,0 +1,23 @@
+# See https://www.jenkins.io/doc/developer/security/scan/
+
+---
+name: Jenkins Security Scan
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  security-scan:
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    with:
+      java-cache: 'maven'
+      java-version: 11


### PR DESCRIPTION
The Jenkins team now provides a GitHub action that scans Jenkins plugins for common Jenkins-plugin security issues.