### PR TITLE
Feature: parse JUnit-XML with testsuites top-level element

### DIFF
--- a/src/main/java/de/tum/in/www1/jenkins/notifications/JunitXmlParser.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/JunitXmlParser.java
@@ -1,0 +1,50 @@
+package de.tum.in.www1.jenkins.notifications;
+
+import com.sun.xml.bind.v2.ContextFactory;
+import de.tum.in.www1.jenkins.notifications.exception.TestParsingException;
+import de.tum.in.www1.jenkins.notifications.model.ObjectFactory;
+import de.tum.in.www1.jenkins.notifications.model.Testsuite;
+import de.tum.in.www1.jenkins.notifications.model.Testsuites;
+import java.io.InputStream;
+import java.util.List;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+public class JunitXmlParser {
+
+    private final JAXBContext context;
+
+    public JunitXmlParser() throws JAXBException {
+        this.context = createJAXBContext();
+    }
+
+    public Testsuites parseJunitTestReport(final InputStream report) throws TestParsingException {
+        try {
+            final Unmarshaller unmarshaller = context.createUnmarshaller();
+            final Object parsedTestResults = unmarshaller.unmarshal(report);
+
+            /*
+             * JUnit XMLs can either have a top-level `<testsuites>` element that contains multiple `<testsuite>`s, or
+             * alternatively, if there is only one test suite, the `<testsuite>` is allowed to appear as the top-most
+             * element in the XML.
+             */
+            if (parsedTestResults instanceof Testsuites) {
+                return (Testsuites) parsedTestResults;
+            } else if (parsedTestResults instanceof Testsuite) {
+                final Testsuites suites = new Testsuites();
+                suites.setTestSuites(List.of((Testsuite) parsedTestResults));
+                return suites;
+            } else {
+                throw new IllegalStateException("Cannot parse " + report + "! Unknown JUnit XML format.");
+            }
+        } catch (JAXBException | IllegalStateException e) {
+            throw new TestParsingException(e);
+        }
+    }
+
+    private JAXBContext createJAXBContext() throws JAXBException {
+        return ContextFactory.createContext(
+                ObjectFactory.class.getPackage().getName(), ObjectFactory.class.getClassLoader(), null);
+    }
+}

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/ObjectFactory.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/ObjectFactory.java
@@ -1,9 +1,8 @@
 package de.tum.in.www1.jenkins.notifications.model;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import de.tum.in.ase.parser.domain.Issue;
 import de.tum.in.ase.parser.domain.Report;
+import javax.xml.bind.annotation.XmlRegistry;
 
 /**
  * Based on <a href="https://github.com/jenkinsci/performance-signature-dynatrace-plugin/pull/81/files">an issue of
@@ -49,6 +48,10 @@ public class ObjectFactory {
 
     public Testsuite createTestsuite() {
         return new Testsuite();
+    }
+
+    public Testsuites createTestsuites() {
+        return new Testsuites();
     }
 
     public Report createReport() {

--- a/src/main/java/de/tum/in/www1/jenkins/notifications/model/Testsuites.java
+++ b/src/main/java/de/tum/in/www1/jenkins/notifications/model/Testsuites.java
@@ -1,0 +1,39 @@
+package de.tum.in.www1.jenkins.notifications.model;
+
+import java.util.List;
+import java.util.stream.Stream;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+@ExportedBean(defaultVisibility = 2)
+@XmlRootElement(name = "testsuites")
+public class Testsuites {
+
+    private List<Testsuite> testSuites;
+
+    @Exported
+    public List<Testsuite> getTestSuites() {
+        return testSuites;
+    }
+
+    @XmlElement(name = "testsuite")
+    public void setTestSuites(List<Testsuite> testSuites) {
+        this.testSuites = testSuites;
+    }
+
+    /**
+     * Flattens all inner test suites.
+     *
+     * @return The test suites flattened to only directly contain test cases.
+     * @see Testsuite#flatten()
+     */
+    public Stream<Testsuite> flattened() {
+        if (testSuites.size() > 1) {
+            return testSuites.stream().map(Testsuite::flattenWithOwnNameAsTestNamePrefix);
+        } else {
+            return testSuites.stream().map(Testsuite::flatten);
+        }
+    }
+}

--- a/src/test/resources/testsuite_examples/multiple_testsuites.xml
+++ b/src/test/resources/testsuite_examples/multiple_testsuites.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="SuiteA" tests="3">
+        <testcase name="Test1"/>
+        <testcase name="Test2"/>
+        <testcase name="Test3"/>
+    </testsuite>
+    <testsuite name="SuiteB" tests="3">
+        <testcase name="Test1"/>
+        <testcase name="Test2"/>
+        <testcase name="Test3"/>
+    </testsuite>
+</testsuites>

--- a/src/test/resources/testsuite_examples/multiple_testsuites_nested.xml
+++ b/src/test/resources/testsuite_examples/multiple_testsuites_nested.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="SuiteA" tests="3">
+        <testsuite name="SuiteC" tests="3">
+            <testcase name="Test1"/>
+            <testcase name="Test2"/>
+            <testcase name="Test3"/>
+        </testsuite>
+        <testcase name="Test nested once"/>
+    </testsuite>
+    <testsuite name="SuiteB" tests="3">
+        <testsuite name="SuiteD" tests="3">
+            <testcase name="Test1"/>
+            <testcase name="Test2"/>
+            <testcase name="Test3"/>
+        </testsuite>
+    </testsuite>
+</testsuites>

--- a/src/test/resources/testsuite_examples/nested_empty_names.xml
+++ b/src/test/resources/testsuite_examples/nested_empty_names.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite>
+        <testsuite>
+            <testsuite>
+                <testcase name="Test1"/>
+                <testcase name="Test2"/>
+                <testcase name="Test3"/>
+            </testsuite>
+        </testsuite>
+    </testsuite>
+</testsuites>

--- a/src/test/resources/testsuite_examples/nested_successful_wrapped_testsuites.xml
+++ b/src/test/resources/testsuite_examples/nested_successful_wrapped_testsuites.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' ?>
+<testsuites>
+    <testsuite name="Tests" tests="12">
+        <testsuite name="Properties" tests="9">
+            <testsuite name="Checked by SmallCheck" tests="6">
+                <testcase name="Testing filtering in A" time="0.004"
+                          classname="Tests.Properties.Checked by SmallCheck"/>
+                <testcase name="Testing mapping in A" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+                <testcase name="Testing filtering in B" time="0.000"
+                          classname="Tests.Properties.Checked by SmallCheck"/>
+                <testcase name="Testing mapping in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+                <testcase name="Testing filtering in C" time="0.003"
+                          classname="Tests.Properties.Checked by SmallCheck"/>
+                <testcase name="Testing mapping in C" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+            </testsuite>
+            <testsuite name="Checked by QuickCheck" tests="3">
+                <testcase name="Testing A against sample solution" time="0.001"
+                          classname="Tests.Properties.Checked by QuickCheck"/>
+                <testcase name="Testing B against sample solution" time="0.001"
+                          classname="Tests.Properties.Checked by QuickCheck"/>
+                <testcase name="Testing C against sample solution" time="0.001"
+                          classname="Tests.Properties.Checked by QuickCheck"/>
+            </testsuite>
+        </testsuite>
+        <!-- artificially introduce unnamed test suite -->
+        <testsuite tests="3">
+            <testcase name="Testing selectAndReflectA (0,0) []" time="0.000" classname="Tests.Unit Tests"/>
+            <testcase name="Testing selectAndReflectB (0,1) [(0,0)]" time="0.000" classname="Tests.Unit Tests"/>
+            <testcase name="Testing selectAndReflectC (0,1) [(-1,-1)]" time="0.000" classname="Tests.Unit Tests"/>
+            <testsuite name="Empty Testsuite" tests="0">
+                <!-- intentionally empty -->
+            </testsuite>
+        </testsuite>
+    </testsuite>
+</testsuites>

--- a/src/test/resources/testsuite_examples/nested_with_failures_top_level_testsuites.xml
+++ b/src/test/resources/testsuite_examples/nested_with_failures_top_level_testsuites.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' ?>
+<testsuites>
+    <testsuite name="Properties" tests="9">
+        <testsuite name="Checked by SmallCheck" tests="6">
+            <testcase name="Testing filtering in A" time="0.000" classname="Tests.Properties.Checked by SmallCheck">
+                <failure>there exist (0,1) [(1,0)] such that
+                    condition is false
+                </failure>
+            </testcase>
+            <testcase name="Testing mapping in A" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+            <testcase name="Testing filtering in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+            <testcase name="Testing mapping in B" time="0.000" classname="Tests.Properties.Checked by SmallCheck"/>
+            <testcase name="Testing filtering in C" time="0.002" classname="Tests.Properties.Checked by SmallCheck"/>
+            <testcase name="Testing mapping in C" time="0.000" classname="Tests.Properties.Checked by SmallCheck">
+                <error>Some error message</error>
+            </testcase>
+        </testsuite>
+        <testsuite name="Checked by QuickCheck" tests="3">
+            <testcase name="Testing A against sample solution" time="0.000"
+                      classname="Tests.Properties.Checked by QuickCheck">
+                <failure>*** Failed! (after 5 tests and 5 shrinks):
+
+                    &gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; expected
+                    [ ( 1 , 0 ) ]
+                    &gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt; but got
+                    [ ( -2 , 0 ) ]
+                    (0,1)
+                    [(1,0)]
+                    Use --quickcheck-replay=220998 to reproduce.
+                </failure>
+            </testcase>
+            <testcase name="Testing B against sample solution" time="0.000"
+                      classname="Tests.Properties.Checked by QuickCheck"/>
+            <testcase name="Testing C against sample solution" time="0.000"
+                      classname="Tests.Properties.Checked by QuickCheck"/>
+        </testsuite>
+    </testsuite>
+    <testsuite name="Unit Tests" tests="3">
+        <testcase name="Testing selectAndReflectA (0,0) []" time="0.000" classname="Tests.Unit Tests"/>
+        <testcase name="Testing selectAndReflectB (0,1) [(0,0)]" time="0.000" classname="Tests.Unit Tests"/>
+        <testcase name="Testing selectAndReflectC (0,1) [(-1,-1)]" time="0.000" classname="Tests.Unit Tests"/>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
Closes #27.

Note: The first commit has only the Spotless reformatting changes, the second commit contains the actual logic changes.

Todo:

- [x] test on Uni Passau testserver

---

Todo @b-fein: Once this is merged and a new release is published, open a PR in the main Artemis repository to remove the `sed` workarounds from the `pipeline.groovy` Jenkins build plans. 